### PR TITLE
Use compression when rsyncing target/ back to the client.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -190,6 +190,7 @@ fn main() {
         Command::new("rsync")
             .arg("-a")
             .arg("--delete")
+            .arg("--compress")
             .arg("--info=progress2")
             .arg(format!("{}:~/remote-builds/{}/target/", build_server, project_name))
             .arg(format!("{}/target/", project_dir.to_string_lossy()))


### PR DESCRIPTION
For a slightly higher CPU usage on the client side, it gives a 7× speedup on the copy of one of my projects.

If the client has a very busy CPU (I tried with an i5-6200U downclocked to 400MHz and load average 4), this change still gives a 2× speedup.

---

By the way, thanks for this project, it's very useful to make my laptop heat less in summer :)