### PR TITLE
Fix progress on MacOS

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ use toml::Value;
 
 use log::{error, info, warn};
 
+const PROGRESS_FLAG: &str = "--info=progress2";
+
 #[derive(StructOpt, Debug)]
 #[structopt(name = "cargo-remote", bin_name = "cargo")]
 enum Opts {


### PR DESCRIPTION
Mac OS seems to ship an old rsync version which doesn't
support `--info=progress2`, but `--progress`. This PR makes
the supplied flag dependent on the target platform.

Related to #2. 