### PR TITLE
More practical workflow.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -225,6 +225,6 @@ fn main() {
     }
 
     if !output.status.success() {
-        exit(output.status.code().unwrap_or(0))
+        exit(output.status.code().unwrap_or(1))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ fn main() {
     );
 
     info!("Starting build process.");
-    Command::new("ssh")
+    let output = Command::new("ssh")
         .arg("-t")
         .arg(&build_server)
         .arg(build_command)
@@ -221,5 +221,9 @@ fn main() {
                 );
                 exit(-6);
             });
+    }
+
+    if !output.status.success() {
+        exit(output.status.code().unwrap_or(0))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,9 @@ enum Opts {
         #[structopt(
             short = "c",
             long = "copy-back",
-            help = "transfer the target folder back to the local machine"
+            help = "transfer the target folder or specific file from that folder back to the local machine"
         )]
-        copy_back: bool,
+        copy_back: Option<Option<String>>,
 
         #[structopt(
             long = "no-copy-lock",
@@ -179,15 +179,16 @@ fn main() {
             exit(-5);
         });
 
-    if copy_back {
+    if let Some(file_name) = copy_back {
         info!("Transferring artifacts back to client.");
+        let file_name = file_name.unwrap_or_else(String::new);
         Command::new("rsync")
             .arg("-a")
             .arg("--delete")
             .arg("--compress")
             .arg("--info=progress2")
-            .arg(format!("{}:{}/target/", build_server, build_path))
-            .arg(format!("{}/target/", project_dir.to_string_lossy()))
+            .arg(format!("{}:{}/target/{}", build_server, build_path, file_name))
+            .arg(format!("{}/target/{}", project_dir.to_string_lossy(), file_name))
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .stdin(Stdio::inherit())

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,7 +220,7 @@ fn main() {
                     "Failed to transfer Cargo.lock back to local machine (error: {})",
                     e
                 );
-                exit(-6);
+                exit(-7);
             });
     }
 


### PR DESCRIPTION
Thanks for that plugin, it really makes my life happier (even though it feels the implementation is pretty hacked :wink:)!

I've added a few features that I miss during day-to-day work with this plugin, namely:

#### Copying back the `Cargo.lock` file.
CI builds are usually run with `--locked`, so that the `Cargo.lock` reflects the latest state of the toml files in the project. When using `cargo remote` I often forget to update the lock file locally.

#### Propagating the error code
With `cargo` I used to chain commands like this:
```
$ cargo test --all && git push
```
So when the tests fail I don't push the branch.

The change brings the same semantics to `cargo-remote`:
```
$ cargo remote -- test --all && git push
```

#### Transferring only the binary back.

Usually I'm not interested in the entire `target` folder, but only a binary that is produced, so I've added optional `String` parameter that reflects a sub-path to copy back.
```
$ cargo remote -c release/my_binary -- build --release
```
