### PR TITLE
Bring back tty allocation, to clean sub-processes.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -205,6 +205,7 @@ fn main() {
 
     info!("Starting build process.");
     let output = Command::new("ssh")
+        .arg("-t")
         .arg(&build_server)
         .arg(build_command)
         .stdout(Stdio::inherit())


### PR DESCRIPTION
It seems that lack of `-t` causes cargo to not be killed after you disconnect. This causes issues running subsequent calls as they fail with lock still being taken.