### PR TITLE
Hash project path to generate unique remote build dir

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,7 @@ fn main() {
     // generate a unique build path by using the hashed project dir as folder on the remote machine
     let mut hasher = DefaultHasher::new();
     project_dir.hash(&mut hasher);
-    let build_path = format!("~/remote-builds/{:?}/", hasher.finish());
+    let build_path = format!("~/remote-builds/{}/", hasher.finish());
 
     info!("Transferring sources to build server.");
     // transfer project to build server


### PR DESCRIPTION
This is useful when you have the same project checked out multiple times
and don't want to share the build dir (because you work on different
stuff).