### PR TITLE
Config with serde & ssh port

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,4 @@ log = "0.4.1"
 simple_logger = "1.3.0"
 xdg = "2.1.0"
 serde = { version = "1.0", features = ["derive"] }
-toml = "0.5.1"
 config = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,7 @@ structopt = "0.2.18"
 cargo_metadata = "0.8.0"
 log = "0.4.1"
 simple_logger = "1.3.0"
-toml = "0.5.1"
 xdg = "2.1.0"
+serde = { version = "1.0", features = ["derive"] }
+toml = "0.5.1"
+config = "0.11"

--- a/README.md
+++ b/README.md
@@ -37,32 +37,42 @@ default remote build host and user. It can be overridden by the `-r` flag.
 
 Example config file:
 ```toml
-remote = "builds@myserver"
+[[remote]]
+name = "myRemote" # Not needed for a single remote
+host = "myUser@myServer" # Could also be a ssh config entry
+ssh_port = 42 # defaults to 22
+temp_dir = "~/rust" # Default is "~/remote-builds"
+env = "~/.profile" # Default is "/etc/profile"
 ```
 
 ### Flags and options
+
 ```
 USAGE:
     cargo remote [FLAGS] [OPTIONS] <command> [remote options]...
 
 FLAGS:
-    -c, --copy-back          Transfer the target folder back to the local machine
         --help               Prints help information
     -h, --transfer-hidden    Transfer hidden files and directories to the build server
+        --no-copy-lock       don't transfer the Cargo.lock file back to the local machine
     -V, --version            Prints version information
 
 OPTIONS:
     -b, --build-env <build_env>              Set remote environment variables. RUST_BACKTRACE, CC, LIB, etc.  [default:
                                              RUST_BACKTRACE=1]
-    -e, --env <env>                          Environment profile. default_value = /etc/profile [default: /etc/profile]
+    -c, --copy-back <copy_back>              Transfer the target folder or specific file from that folder back to the
+                                             local machine
+    -e, --env <env>                          Environment profile. default_value = /etc/profile
+    -H, --remote-host <host>                 Remote ssh build server with user or the name of the ssh entry
         --manifest-path <manifest_path>      Path to the manifest to execute [default: Cargo.toml]
-    -r, --remote <remote>                    Remote ssh build server
+    -r, --remote <name>                      The name of the remote specified in the config
     -d, --rustup-default <rustup_default>    Rustup default (stable|beta|nightly) [default: stable]
+    -p, --remote-ssh-port <ssh_port>         The ssh port to communicate with the build server
+    -t, --remote-temp-dir <temp_dir>         The directory where cargo builds the project
 
 ARGS:
     <command>              cargo command that will be executed remotely
     <remote options>...    cargo options and flags that will be applied remotely
-
 ```
 
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ pub struct Remote {
     pub host: String,
     pub ssh_port: u16,
     pub temp_dir: String,
+    pub env: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -14,6 +15,7 @@ struct PartialRemote {
     pub host: String,
     pub ssh_port: Option<u16>,
     pub temp_dir: Option<String>,
+    pub env: Option<String>,
 }
 
 impl Default for Remote {
@@ -23,6 +25,7 @@ impl Default for Remote {
             host: String::new(),
             ssh_port: 22,
             temp_dir: "~/remote-builds".to_string(),
+            env: "/etc/profile".to_string(),
         }
     }
 }
@@ -33,11 +36,13 @@ impl From<PartialRemote> for Remote {
         let name = minimal_remote.name.unwrap_or(default.name);
         let ssh_port = minimal_remote.ssh_port.unwrap_or(default.ssh_port);
         let temp_dir = minimal_remote.temp_dir.unwrap_or(default.temp_dir);
+        let env = minimal_remote.env.unwrap_or(default.env);
         Remote {
             name,
             host: minimal_remote.host,
             ssh_port,
             temp_dir,
+            env,
         }
     }
 }
@@ -96,6 +101,7 @@ impl Config {
             host: opts.host.clone().unwrap_or(blueprint_remote.host),
             ssh_port: opts.ssh_port.clone().unwrap_or(blueprint_remote.ssh_port),
             temp_dir: opts.temp_dir.clone().unwrap_or(blueprint_remote.temp_dir),
+            env: opts.env.clone().unwrap_or(blueprint_remote.env),
         })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,21 +1,57 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone)]
 pub struct Remote {
+    pub name: String,
     pub host: String,
     pub user: String,
     pub ssh_port: u16,
     pub temp_dir: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct OptionRemote {
+    pub name: Option<String>,
+    pub host: String,
+    pub user: String,
+    pub ssh_port: Option<u16>,
+    pub temp_dir: Option<String>,
+}
+
 impl Default for Remote {
     fn default() -> Self {
         Self {
+            name: String::new(),
             host: String::new(),
             user: String::new(),
             ssh_port: 22,
             temp_dir: "~/remote-builds".to_string(),
         }
+    }
+}
+
+impl From<OptionRemote> for Remote {
+    fn from(minimal_remote: OptionRemote) -> Self {
+        let default = Remote::default();
+        let name = minimal_remote.name.unwrap_or(default.name);
+        let ssh_port = minimal_remote.ssh_port.unwrap_or(default.ssh_port);
+        let temp_dir = minimal_remote.temp_dir.unwrap_or(default.temp_dir);
+        Remote {
+            name,
+            host: minimal_remote.host,
+            user: minimal_remote.user,
+            ssh_port,
+            temp_dir,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Remote {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        OptionRemote::deserialize(deserializer).map(Self::from)
     }
 }
 
@@ -25,19 +61,15 @@ impl Remote {
     }
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct Config {
-    pub remote: Remote,
+    #[serde(rename = "remote")]
+    remotes: Option<Vec<Remote>>,
 }
 
 impl Config {
     pub fn new(project_dir: &std::path::Path) -> Result<Self, config::ConfigError> {
-        let mut conf = config::Config::default();
-
-        conf.merge(config::File::from_str(
-            toml::to_string(&Config::default()).unwrap().as_str(),
-            config::FileFormat::Toml,
-        ))?;
+        let mut conf = config::Config::new();
 
         if let Some(config_file) = xdg::BaseDirectories::with_prefix("cargo-remote")
             .ok()
@@ -52,5 +84,38 @@ impl Config {
         }
 
         conf.try_into()
+    }
+
+    pub fn get_remote(&self, opts: &crate::Opts) -> Option<Remote> {
+        let remotes: Vec<_> = self.remotes.clone().unwrap_or_default();
+        let config_remote = match &opts.remote_name {
+            Some(remote_name) => remotes
+                .into_iter()
+                .find(|remote| remote.name == *remote_name),
+            None => remotes.into_iter().next(),
+        };
+
+        let blueprint_remote = match (
+            config_remote,
+            opts.remote_host.is_some() && opts.remote_user.is_some(),
+        ) {
+            (Some(config_remote), _) => config_remote,
+            (None, true) => Remote::default(),
+            (None, false) => return None,
+        };
+
+        Some(Remote {
+            name: opts.remote_name.clone().unwrap_or(blueprint_remote.name),
+            host: opts.remote_host.clone().unwrap_or(blueprint_remote.host),
+            user: opts.remote_user.clone().unwrap_or(blueprint_remote.user),
+            ssh_port: opts
+                .remote_ssh_port
+                .clone()
+                .unwrap_or(blueprint_remote.ssh_port),
+            temp_dir: opts
+                .remote_temp_dir
+                .clone()
+                .unwrap_or(blueprint_remote.temp_dir),
+        })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,56 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Remote {
+    pub host: String,
+    pub user: String,
+    pub ssh_port: u16,
+    pub temp_dir: String,
+}
+
+impl Default for Remote {
+    fn default() -> Self {
+        Self {
+            host: String::new(),
+            user: String::new(),
+            ssh_port: 22,
+            temp_dir: "~/remote-builds".to_string(),
+        }
+    }
+}
+
+impl Remote {
+    pub fn user_host(&self) -> String {
+        format!("{}@{}", self.user, self.host)
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct Config {
+    pub remote: Remote,
+}
+
+impl Config {
+    pub fn new(project_dir: &std::path::Path) -> Result<Self, config::ConfigError> {
+        let mut conf = config::Config::default();
+
+        conf.merge(config::File::from_str(
+            toml::to_string(&Config::default()).unwrap().as_str(),
+            config::FileFormat::Toml,
+        ))?;
+
+        if let Some(config_file) = xdg::BaseDirectories::with_prefix("cargo-remote")
+            .ok()
+            .and_then(|base| base.find_config_file("cargo-remote.toml"))
+        {
+            conf.merge(config::File::from(config_file))?;
+        }
+
+        let project_config = project_dir.join(".cargo-remote.toml");
+        if project_config.is_file() {
+            conf.merge(config::File::from(project_config))?;
+        }
+
+        conf.try_into()
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,7 @@ pub struct Remote {
 }
 
 #[derive(Debug, Deserialize)]
-struct OptionRemote {
+struct PartialRemote {
     pub name: Option<String>,
     pub host: String,
     pub user: String,
@@ -30,8 +30,8 @@ impl Default for Remote {
     }
 }
 
-impl From<OptionRemote> for Remote {
-    fn from(minimal_remote: OptionRemote) -> Self {
+impl From<PartialRemote> for Remote {
+    fn from(minimal_remote: PartialRemote) -> Self {
         let default = Remote::default();
         let name = minimal_remote.name.unwrap_or(default.name);
         let ssh_port = minimal_remote.ssh_port.unwrap_or(default.ssh_port);
@@ -51,7 +51,7 @@ impl<'de> Deserialize<'de> for Remote {
     where
         D: serde::Deserializer<'de>,
     {
-        OptionRemote::deserialize(deserializer).map(Self::from)
+        PartialRemote::deserialize(deserializer).map(Self::from)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,16 +12,20 @@ const PROGRESS_FLAG: &str = "--info=progress2";
 
 #[derive(StructOpt, Debug)]
 pub struct RemoteOpts {
-    #[structopt(short = "r", long = "remote", help = "Remote ssh build server")]
+    /// The name of the remote specified in the config
+    #[structopt(short = "r", long = "remote")]
     name: Option<String>,
 
-    #[structopt(short, long, help = "")]
+    /// Remote ssh build server with user or the name of the ssh entry
+    #[structopt(short = "H", long = "remote-host")]
     host: Option<String>,
 
-    #[structopt(short, long, help = "")]
+    /// The ssh port to communicate with the build server
+    #[structopt(short = "p", long = "remote-ssh-port")]
     ssh_port: Option<u16>,
 
-    #[structopt(short, long, help = "")]
+    /// The directory where cargo builds the project
+    #[structopt(short, long = "remote-temp-dir")]
     temp_dir: Option<String>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,92 +11,109 @@ mod config;
 const PROGRESS_FLAG: &str = "--info=progress2";
 
 #[derive(StructOpt, Debug)]
-#[structopt(name = "cargo-remote", bin_name = "cargo")]
-pub struct Opts {
+pub struct RemoteOpts {
     #[structopt(short = "r", long = "remote", help = "Remote ssh build server")]
-    remote_name: Option<String>,
+    name: Option<String>,
 
     #[structopt(short, long, help = "")]
-    remote_host: Option<String>,
+    host: Option<String>,
 
     #[structopt(short, long, help = "")]
-    remote_user: Option<String>,
+    ssh_port: Option<u16>,
 
     #[structopt(short, long, help = "")]
-    remote_ssh_port: Option<u16>,
+    temp_dir: Option<String>,
+}
 
-    #[structopt(short, long, help = "")]
-    remote_temp_dir: Option<String>,
+#[derive(StructOpt, Debug)]
+#[structopt(name = "cargo-remote", bin_name = "cargo")]
+enum Opts {
+    #[structopt(name = "remote")]
+    Remote {
+        #[structopt(flatten)]
+        remote_opts: RemoteOpts,
 
-    #[structopt(
-        short = "b",
-        long = "build-env",
-        help = "Set remote environment variables. RUST_BACKTRACE, CC, LIB, etc. ",
-        default_value = "RUST_BACKTRACE=1"
-    )]
-    build_env: String,
+        #[structopt(
+            short = "b",
+            long = "build-env",
+            help = "Set remote environment variables. RUST_BACKTRACE, CC, LIB, etc. ",
+            default_value = "RUST_BACKTRACE=1"
+        )]
+        build_env: String,
 
-    #[structopt(
-        short = "d",
-        long = "rustup-default",
-        help = "Rustup default (stable|beta|nightly)",
-        default_value = "stable"
-    )]
-    rustup_default: String,
+        #[structopt(
+            short = "d",
+            long = "rustup-default",
+            help = "Rustup default (stable|beta|nightly)",
+            default_value = "stable"
+        )]
+        rustup_default: String,
 
-    #[structopt(
-        short = "e",
-        long = "env",
-        help = "Environment profile. default_value = /etc/profile",
-        default_value = "/etc/profile"
-    )]
-    env: String,
+        #[structopt(
+            short = "e",
+            long = "env",
+            help = "Environment profile. default_value = /etc/profile",
+            default_value = "/etc/profile"
+        )]
+        env: String,
 
-    #[structopt(
-        short = "c",
-        long = "copy-back",
-        help = "Transfer the target folder or specific file from that folder back to the local machine"
-    )]
-    copy_back: Option<Option<String>>,
+        #[structopt(
+            short = "c",
+            long = "copy-back",
+            help = "Transfer the target folder or specific file from that folder back to the local machine"
+        )]
+        copy_back: Option<Option<String>>,
 
-    #[structopt(
-        long = "no-copy-lock",
-        help = "don't transfer the Cargo.lock file back to the local machine"
-    )]
-    no_copy_lock: bool,
+        #[structopt(
+            long = "no-copy-lock",
+            help = "don't transfer the Cargo.lock file back to the local machine"
+        )]
+        no_copy_lock: bool,
 
-    #[structopt(
-        long = "manifest-path",
-        help = "Path to the manifest to execute",
-        default_value = "Cargo.toml",
-        parse(from_os_str)
-    )]
-    manifest_path: PathBuf,
+        #[structopt(
+            long = "manifest-path",
+            help = "Path to the manifest to execute",
+            default_value = "Cargo.toml",
+            parse(from_os_str)
+        )]
+        manifest_path: PathBuf,
 
-    #[structopt(
-        short = "h",
-        long = "transfer-hidden",
-        help = "Transfer hidden files and directories to the build server"
-    )]
-    hidden: bool,
+        #[structopt(
+            short = "h",
+            long = "transfer-hidden",
+            help = "Transfer hidden files and directories to the build server"
+        )]
+        hidden: bool,
 
-    #[structopt(help = "cargo command that will be executed remotely")]
-    command: String,
+        #[structopt(help = "cargo command that will be executed remotely")]
+        command: String,
 
-    #[structopt(
-        help = "cargo options and flags that will be applied remotely",
-        name = "remote options"
-    )]
-    options: Vec<String>,
+        #[structopt(
+            help = "cargo options and flags that will be applied remotely",
+            name = "remote options"
+        )]
+        options: Vec<String>,
+    },
 }
 
 fn main() {
     simple_logger::init().unwrap();
 
-    let opts = Opts::from_args();
+    let Opts::Remote {
+        remote_opts,
+        build_env,
+        rustup_default,
+        env,
+        copy_back,
+        no_copy_lock,
+        manifest_path,
+        hidden,
+        command,
+        options,
+    } = Opts::from_args();
 
     let mut metadata_cmd = cargo_metadata::MetadataCommand::new();
-    metadata_cmd.manifest_path(&opts.manifest_path).no_deps();
+    metadata_cmd.manifest_path(manifest_path).no_deps();
 
     let project_metadata = metadata_cmd.exec().unwrap();
     let project_dir = project_metadata.workspace_root;
@@ -110,7 +127,7 @@ fn main() {
         }
     };
 
-    let remote = match conf.get_remote(&opts) {
+    let remote = match conf.get_remote(&remote_opts) {
         Some(remote) => remote,
         None => {
             error!("No remote build server was defined (use config file or the --remote flags)");
@@ -118,19 +135,7 @@ fn main() {
         }
     };
 
-    let build_server = remote.user_host();
-
-    let Opts {
-        build_env,
-        rustup_default,
-        env,
-        copy_back,
-        no_copy_lock,
-        hidden,
-        command,
-        options,
-        ..
-    } = opts;
+    let build_server = remote.host;
 
     // generate a unique build path by using the hashed project dir as folder on the remote machine
     let mut hasher = DefaultHasher::new();
@@ -144,7 +149,7 @@ fn main() {
         .arg("-a".to_owned())
         .arg("--delete")
         .arg("--compress")
-        .arg(format!("-e ssh -p {}", remote.ssh_port))
+        .args(&["-e", "ssh", "-p", &remote.ssh_port.to_string()])
         .arg("--info=progress2")
         .arg("--exclude")
         .arg("target");
@@ -181,7 +186,7 @@ fn main() {
 
     info!("Starting build process.");
     let output = Command::new("ssh")
-        .arg(format!("-p {}", remote.ssh_port))
+        .args(&["-p", &remote.ssh_port.to_string()])
         .arg("-t")
         .arg(&build_server)
         .arg(build_command)
@@ -201,7 +206,8 @@ fn main() {
             .arg("-a")
             .arg("--delete")
             .arg("--compress")
-            .arg(format!("-e ssh -p {}", remote.ssh_port))
+            .args(&["-e", "ssh", "-p", &remote.ssh_port.to_string()])
+            .arg("--info=progress2")
             .arg("--info=progress2")
             .arg(format!(
                 "{}:{}/target/{}",
@@ -231,7 +237,8 @@ fn main() {
             .arg("-a")
             .arg("--delete")
             .arg("--compress")
-            .arg(format!("-e ssh -p {}", remote.ssh_port))
+            .args(&["-e", "ssh", "-p", &remote.ssh_port.to_string()])
+            .arg("--info=progress2")
             .arg("--info=progress2")
             .arg(format!("{}:{}/Cargo.lock", build_server, build_path))
             .arg(format!("{}/Cargo.lock", project_dir.to_string_lossy()))


### PR DESCRIPTION
The configuration could look like this:
```toml
[remote]
host = "some-server"
user = "some-user"
ssh_port = 42
temp_dir = "~/some-dir"
```
All config options are optional. A check for having a host & user specified, either through cli or config, has to be implemented.
But an alternative could be to allow multiple remotes and picking either the first or one which was specified with a name in the cli (Information for myself: [serde-piecewise-default](https://crates.io/crates/serde_piecewise_default) has to be used).
I splitted the host and user into 2 separate entries but I could change that.

The changed command arguments are untested and derived from #13.