### PR TITLE
Add --working-directory option to support local dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ description = "Cargo subcommand to build rust projects remotely"
 keywords = ["remote", "build"]
 categories = ["command-line-utilities", "development-tools::build-utils", "development-tools::cargo-plugins"]
 maintenance = { status = "experimental" }
-version = "0.2.0"
-authors = ["Sebastian Geisler <sgeisler@wh2.tu-dresden.de>"]
+version = "0.2.1"
+authors = ["Sebastian Geisler <sgeisler@wh2.tu-dresden.de>", "Zannis Kalampoukis <zannis.kal@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/sgeisler/cargo-remote"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Cargo subcommand to build rust projects remotely"
 keywords = ["remote", "build"]
 categories = ["command-line-utilities", "development-tools::build-utils", "development-tools::cargo-plugins"]
 maintenance = { status = "experimental" }
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Sebastian Geisler <sgeisler@wh2.tu-dresden.de>", "Zannis Kalampoukis <zannis.kal@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/sgeisler/cargo-remote"

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ OPTIONS:
     -d, --rustup-default <rustup_default>    Rustup default (stable|beta|nightly) [default: stable]
     -p, --remote-ssh-port <ssh_port>         The ssh port to communicate with the build server
     -t, --remote-temp-dir <temp_dir>         The directory where cargo builds the project
+    -w, --working-directory <local_dir>      The local directory to use as project root. Useful when there are local dependencies outside the workspace directory.
 
 ARGS:
     <command>              cargo command that will be executed remotely

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 use std::process::{exit, Command, Stdio};
+use std::fs::canonicalize;
 use structopt::StructOpt;
 
 use log::{error, info};
@@ -128,7 +129,8 @@ fn main() {
     let project_metadata = metadata_cmd.exec().unwrap();
 
     let project_dir = match working_directory {
-        Some(path) => PathBuf::from(path),
+        Some(path) => canonicalize(PathBuf::from(path))
+            .expect("The provided working directory does not exist or has an error."),
         None => project_metadata.workspace_root.clone()
     };
     info!("Workspace root: {:?}", project_metadata.workspace_root.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,13 +139,11 @@ fn main() {
     );
     info!("Project root: {:?}", project_root);
 
-    let diff_from_project_root = canonicalize(
-        PathBuf::from(project_metadata.workspace_root.clone())
-            .strip_prefix(project_root.clone())
-            .expect("Working directory should be an ancestor of the workspace root")
-            .to_owned(),
-    )
-    .expect("The provided directory does not exist or has an error.");
+    let diff_from_project_root = project_metadata
+        .workspace_root
+        .strip_prefix(project_root.clone())
+        .expect("Working directory should be an ancestor of the workspace root")
+        .to_owned();
 
     let conf = match config::Config::new(&project_root) {
         Ok(conf) => conf,
@@ -172,11 +170,9 @@ fn main() {
 
     let mut build_workspace = PathBuf::from(build_path.clone());
     build_workspace.push(diff_from_project_root.clone());
-    let build_workspace = canonicalize(build_workspace).expect("Path should exist");
 
     let mut project_workspace = project_root.clone();
     project_workspace.push(diff_from_project_root);
-    let project_workspace = canonicalize(project_workspace).expect("Path should exist");
 
     info!("Transferring sources to build server.");
     // transfer project to build server


### PR DESCRIPTION
This PR adds the -w or --working-directory option to handle cases where a project has local dependencies such as git submodules, and there are pieces of code located outside the workspace root.

It's expected that the path provided as working directory is a parent path of the workspace otherwise execution will fail.

This feature been in use for a few months now as part of our project in t3rn and seems to be stable but kindly let me know if you find any bugs or issues.

This also resolves #12 .